### PR TITLE
Missing Value in database

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -34,7 +34,7 @@ async def create_device(data: CreateLnurldevice, req: Request) -> Lnurldevice:
             )
 
     await db.execute(
-        "INSERT INTO devicetimer.device (id, key, title, wallet, currency, available_start, available_stop, timeout, timezone, closed_url, wait_url, maxperday, switches) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO devicetimer.device (id, key, title, wallet, currency, available_start, available_stop, timeout, timezone, closed_url, wait_url, maxperday, switches) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             device_id,
             device_key,


### PR DESCRIPTION
There was this error. I also tryed on your instance. Same error.


![DT_groeser 0_12_05_error](https://github.com/pieterjm/DeviceTimer/assets/106493492/9dbfb80a-f078-4bc3-8f0f-2394ead2946d)


I fixed it by adding a value to the await db.execute thing. Tryed it on ym server. Works fine :)
